### PR TITLE
imposeOrderFlowFee Tests

### DIFF
--- a/src/Account.sol
+++ b/src/Account.sol
@@ -219,7 +219,7 @@ contract Account is IAccount, Auth, OpsReady {
     {
         // fetch current sUSD exchange rate for market
         (sUSDmarketRate,) = _sUSDRate(IPerpsV2MarketConsolidated(_market));
-        
+
         orderFlowFee = _calculateOrderFlowFee(_market, _sizeDelta);
     }
 
@@ -618,9 +618,14 @@ contract Account is IAccount, Auth, OpsReady {
     /// @dev if fee is deducted from market's margin, then the following order
     /// may be rejected if the account has insufficient available market margin
     /// @dev _desiredFillPrice is used to calculate orderFlowFee with correct price for Delayed orders
-    function _imposeOrderFlowFee(address _market, int256 _sizeDelta, uint256 _desiredFillPrice) internal {
+    function _imposeOrderFlowFee(
+        address _market,
+        int256 _sizeDelta,
+        uint256 _desiredFillPrice
+    ) internal {
         // calculate order flow fee
-        uint256 fee = _calculateOrderFlowFee(_market, _sizeDelta, _desiredFillPrice);
+        uint256 fee =
+            _calculateOrderFlowFee(_market, _sizeDelta, _desiredFillPrice);
 
         if (fee != 0) {
             uint256 idleMargin = freeMargin();
@@ -661,11 +666,11 @@ contract Account is IAccount, Auth, OpsReady {
     /// @param _desiredFillPrice desiredFillPrice in case of a delayed Order
     /// @return fee: order flow fee to impose
     /// @dev _desiredFillPrice is used to calculate orderFlowFee for Delayed Orders
-    function _calculateOrderFlowFee(address _market, int256 _sizeDelta, uint256 _desiredFillPrice)
-        internal
-        view
-        returns (uint256)
-    {
+    function _calculateOrderFlowFee(
+        address _market,
+        int256 _sizeDelta,
+        uint256 _desiredFillPrice
+    ) internal view returns (uint256) {
         // fetch order flow fee from settings
         uint256 orderFlowFee = SETTINGS.orderFlowFee();
 

--- a/src/Account.sol
+++ b/src/Account.sol
@@ -215,9 +215,12 @@ contract Account is IAccount, Auth, OpsReady {
         public
         view
         override
-        returns (uint256)
+        returns (uint256 sUSDmarketRate, uint256 orderFlowFee)
     {
-        return _calculateOrderFlowFee(_market, _sizeDelta);
+        // fetch current sUSD exchange rate for market
+        (sUSDmarketRate,) = _sUSDRate(IPerpsV2MarketConsolidated(_market));
+        
+        orderFlowFee = _calculateOrderFlowFee(_market, _sizeDelta);
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -608,14 +611,16 @@ contract Account is IAccount, Auth, OpsReady {
     /// @notice impose an order flow fee on the account
     /// @param _market: address of market
     /// @param _sizeDelta: size delta of order
+    /// @param _desiredFillPrice: desiredFillPrice if this is a delayed order, 0 otherwise
     /// @dev will attempt to deduct fee from account's idle margin first
     /// @dev if fee exceeds idle margin, fee will be deducted from market's margin
     /// if possible. If not possible, the transaction will revert.
     /// @dev if fee is deducted from market's margin, then the following order
     /// may be rejected if the account has insufficient available market margin
-    function _imposeOrderFlowFee(address _market, int256 _sizeDelta) internal {
+    /// @dev _desiredFillPrice is used to calculate orderFlowFee with correct price for Delayed orders
+    function _imposeOrderFlowFee(address _market, int256 _sizeDelta, uint256 _desiredFillPrice) internal {
         // calculate order flow fee
-        uint256 fee = _calculateOrderFlowFee(_market, _sizeDelta);
+        uint256 fee = _calculateOrderFlowFee(_market, _sizeDelta, _desiredFillPrice);
 
         if (fee != 0) {
             uint256 idleMargin = freeMargin();
@@ -638,11 +643,25 @@ contract Account is IAccount, Auth, OpsReady {
         EVENTS.emitOrderFlowFeeImposed({amount: fee});
     }
 
+    /// @notice impose an order flow fee on the account
+    /// @param _market: address of market
+    /// @param _sizeDelta: size delta of order
+    /// @dev will attempt to deduct fee from account's idle margin first
+    /// @dev if fee exceeds idle margin, fee will be deducted from market's margin
+    /// if possible. If not possible, the transaction will revert.
+    /// @dev if fee is deducted from market's margin, then the following order
+    /// may be rejected if the account has insufficient available market margin
+    function _imposeOrderFlowFee(address _market, int256 _sizeDelta) internal {
+        _imposeOrderFlowFee(_market, _sizeDelta, 0);
+    }
+
     /// @notice calculate order flow fee for a given market and size delta
     /// @param _market: address of market
     /// @param _sizeDelta: size delta of order
+    /// @param _desiredFillPrice desiredFillPrice in case of a delayed Order
     /// @return fee: order flow fee to impose
-    function _calculateOrderFlowFee(address _market, int256 _sizeDelta)
+    /// @dev _desiredFillPrice is used to calculate orderFlowFee for Delayed Orders
+    function _calculateOrderFlowFee(address _market, int256 _sizeDelta, uint256 _desiredFillPrice)
         internal
         view
         returns (uint256)
@@ -654,11 +673,25 @@ contract Account is IAccount, Auth, OpsReady {
         IPerpsV2MarketConsolidated market = IPerpsV2MarketConsolidated(_market);
         (uint256 price,) = _sUSDRate(market);
 
+        uint256 usedPrice = (_desiredFillPrice != 0) ? _desiredFillPrice : price;
+
         // calculate notional value of order
-        uint256 notionalValue = _abs(_sizeDelta) * price;
+        uint256 notionalValue = _abs(_sizeDelta) * usedPrice;
 
         // calculate fee to impose
         return notionalValue * orderFlowFee / SETTINGS.MAX_ORDER_FLOW_FEE();
+    }
+
+    /// @notice calculate order flow fee for a given market and size delta
+    /// @param _market: address of market
+    /// @param _sizeDelta: size delta of order
+    /// @return fee: order flow fee to impose
+    function _calculateOrderFlowFee(address _market, int256 _sizeDelta)
+        internal
+        view
+        returns (uint256)
+    {
+        _calculateOrderFlowFee(_market, _sizeDelta, 0);
     }
 
     /*//////////////////////////////////////////////////////////////
@@ -774,8 +807,7 @@ contract Account is IAccount, Auth, OpsReady {
         int256 _sizeDelta,
         uint256 _desiredFillPrice
     ) internal {
-        /// @custom:todo use _desiredFillPrice
-        _imposeOrderFlowFee(_market, _sizeDelta);
+        _imposeOrderFlowFee(_market, _sizeDelta, _desiredFillPrice);
 
         IPerpsV2MarketConsolidated(_market)
             .submitOffchainDelayedOrderWithTracking({
@@ -800,12 +832,12 @@ contract Account is IAccount, Auth, OpsReady {
         address _market,
         uint256 _desiredFillPrice
     ) internal {
-        /// @custom:todo use _desiredFillPrice
         _imposeOrderFlowFee(
             _market,
             IPerpsV2MarketConsolidated(_market).positions({
                 account: address(this)
-            }).size
+            }).size,
+            _desiredFillPrice
         );
 
         // close position (i.e. reduce size to zero)

--- a/src/Account.sol
+++ b/src/Account.sol
@@ -635,7 +635,7 @@ contract Account is IAccount, Auth, OpsReady {
             MARGIN_ASSET.transfer(SETTINGS.TREASURY(), fee);
         }
 
-        /// @custom:todo add event emission for order flow fee imposed
+        EVENTS.emitOrderFlowFeeImposed({amount: fee});
     }
 
     /// @notice calculate order flow fee for a given market and size delta
@@ -886,7 +886,7 @@ contract Account is IAccount, Auth, OpsReady {
             execAddress: address(this),
             execData: abi.encodeCall(
                 this.executeConditionalOrder, conditionalOrderId
-                ),
+            ),
             moduleData: moduleData,
             feeToken: ETH
         });

--- a/src/Account.sol
+++ b/src/Account.sol
@@ -682,16 +682,12 @@ contract Account is IAccount, Auth, OpsReady {
         return notionalValue * orderFlowFee / SETTINGS.MAX_ORDER_FLOW_FEE();
     }
 
-    /// @notice calculate order flow fee for a given market and size delta
-    /// @param _market: address of market
-    /// @param _sizeDelta: size delta of order
-    /// @return fee: order flow fee to impose
     function _calculateOrderFlowFee(address _market, int256 _sizeDelta)
         internal
         view
-        returns (uint256)
+        returns (uint256 orderflowFee)
     {
-        _calculateOrderFlowFee(_market, _sizeDelta, 0);
+        orderflowFee = _calculateOrderFlowFee(_market, _sizeDelta, 0);
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/src/Account.sol
+++ b/src/Account.sol
@@ -1058,7 +1058,8 @@ contract Account is IAccount, Auth, OpsReady {
             _amount: conditionalOrder.marginDelta
         });
 
-        _imposeOrderFlowFee(address(market), conditionalOrder.sizeDelta);
+        // Use conditionalOrder.desiredFillPrice as the submitted order is a delayed order
+        _imposeOrderFlowFee(address(market), conditionalOrder.sizeDelta, conditionalOrder.desiredFillPrice);
 
         _perpsV2SubmitOffchainDelayedOrder({
             _market: address(market),

--- a/src/Account.sol
+++ b/src/Account.sol
@@ -1058,9 +1058,6 @@ contract Account is IAccount, Auth, OpsReady {
             _amount: conditionalOrder.marginDelta
         });
 
-        // Use conditionalOrder.desiredFillPrice as the submitted order is a delayed order
-        _imposeOrderFlowFee(address(market), conditionalOrder.sizeDelta, conditionalOrder.desiredFillPrice);
-
         _perpsV2SubmitOffchainDelayedOrder({
             _market: address(market),
             _sizeDelta: conditionalOrder.sizeDelta,

--- a/src/Events.sol
+++ b/src/Events.sol
@@ -171,5 +171,12 @@ contract Events is IEvents {
         emit DelegatedAccountRemoved({caller: caller, delegate: delegate});
     }
 
-    /// @custom:todo add event for order flow fee imposed
+    /// @inheritdoc IEvents
+    function emitOrderFlowFeeImposed(uint256 amount)
+        external
+        override
+        onlyAccounts
+    {
+        emit OrderFlowFeeImposed({account: msg.sender, amount: amount});
+    }
 }

--- a/src/interfaces/IAccount.sol
+++ b/src/interfaces/IAccount.sol
@@ -214,11 +214,12 @@ interface IAccount {
     /// @notice get the expected order flow fee for a given market and size delta
     /// @param _market: address of market
     /// @param _sizeDelta: size delta of order
-    /// @return order flow fee expected for the given market and size delta
+    /// @return sUSDmarketRate sUSD exchange rate for market
+    /// @return orderFlowFee order flow fee expected for the given market and size delta
     function getExpectedOrderFlowFee(address _market, int256 _sizeDelta)
         external
         view
-        returns (uint256);
+        returns (uint256 sUSDmarketRate, uint256 orderFlowFee);
 
     /*//////////////////////////////////////////////////////////////
                                 MUTATIVE

--- a/src/interfaces/IEvents.sol
+++ b/src/interfaces/IEvents.sol
@@ -178,6 +178,9 @@ interface IEvents {
         address indexed caller, address indexed delegate
     );
 
-    /// @custom:todo add event function for order flow fee imposed
-    /// @custom:todo add event for order flow fee imposed
+    /// @notice emitted after order flow fee is imposed
+    /// @param amount: amount of the imposed order flow fee
+    function emitOrderFlowFeeImposed(uint256 amount) external;
+
+    event OrderFlowFeeImposed(address indexed account, uint256 amount);
 }

--- a/test/integration/orderFlowFee.behavior.t.sol
+++ b/test/integration/orderFlowFee.behavior.t.sol
@@ -158,7 +158,7 @@ contract OrderFlowFeeTest is Test, ConsolidatedEvents {
         }
     }
 
-    /// Verifies that OrderFlowFee is correctly sent from account margin to treasury 
+    /// Verifies that OrderFlowFee is correctly sent from account margin to treasury
     // when there is enough funds in account margin to cover orderFlowFee
     function test_imposeOrderFlowFee_account_margin() public {
         fundAccount(AMOUNT);
@@ -193,7 +193,7 @@ contract OrderFlowFeeTest is Test, ConsolidatedEvents {
         assertEq(treasuryPostBalance - treasuryPreBalance, imposedOrderFlowFee);
     }
 
-    /// Verifies that OrderFlowFee is correctly sent from market margin to treasury 
+    /// Verifies that OrderFlowFee is correctly sent from market margin to treasury
     // when there is no funds in account margin to cover orderFlowFee in account margin
     function test_imposeOrderFlowFee_market_margin() public {
         fundAccount(AMOUNT);
@@ -226,10 +226,12 @@ contract OrderFlowFeeTest is Test, ConsolidatedEvents {
         assertEq(treasuryPostBalance - treasuryPreBalance, imposedOrderFlowFee);
     }
 
-    /// Verifies that OrderFlowFee is correctly sent from market margin to treasury 
+    /// Verifies that OrderFlowFee is correctly sent from market margin to treasury
     // when there is no funds in account margin to cover orderFlowFee in account margin
     // with a pending order to confirm locked margin is not used in this case
-    function test_imposeOrderFlowFee_market_margin_with_pending_order() public {
+    function test_imposeOrderFlowFee_market_margin_with_pending_order()
+        public
+    {
         fundAccount(AMOUNT);
 
         uint256 treasuryPreBalance = sUSD.balanceOf(settings.TREASURY());
@@ -256,7 +258,8 @@ contract OrderFlowFeeTest is Test, ConsolidatedEvents {
         assertEq(account.committedMargin(), conditionalOrderMarginDelta);
 
         /// Deposit all remaining margin so that account has no margin to cover orderFlowFee
-        int256 marginDelta = int256(AMOUNT) - int256(conditionalOrderMarginDelta);
+        int256 marginDelta =
+            int256(AMOUNT) - int256(conditionalOrderMarginDelta);
         int256 sizeDelta = 1;
 
         (uint256 desiredFillPrice,) =
@@ -265,7 +268,7 @@ contract OrderFlowFeeTest is Test, ConsolidatedEvents {
         submitAtomicOrder(sETHPERP, marginDelta, sizeDelta, desiredFillPrice);
 
         // Assert that locked account margin was not used to cover fee
-        assertEq(account.committedMargin(), conditionalOrderMarginDelta); 
+        assertEq(account.committedMargin(), conditionalOrderMarginDelta);
 
         uint256 treasuryPostBalance = sUSD.balanceOf(settings.TREASURY());
 
@@ -276,12 +279,15 @@ contract OrderFlowFeeTest is Test, ConsolidatedEvents {
             account.getExpectedOrderFlowFee(market, position.size);
 
         // Assert that fee was correctly sent from market margin
-        assertEq(uint256(position.margin), uint256(marginDelta) - imposedOrderFlowFee - 563);
+        assertEq(
+            uint256(position.margin),
+            uint256(marginDelta) - imposedOrderFlowFee - 563
+        );
         // Assert that fee was correctly sent to treasury address
         assertEq(treasuryPostBalance - treasuryPreBalance, imposedOrderFlowFee);
     }
 
-    /// Verifies that OrderFlowFee is correctly sent from both market margin and account margin 
+    /// Verifies that OrderFlowFee is correctly sent from both market margin and account margin
     // when there is not enough funds to cover orderFlowFee in account margin
     function test_imposeOrderFlowFee_both_margin() public {
         fundAccount(AMOUNT);

--- a/test/integration/orderFlowFee.behavior.t.sol
+++ b/test/integration/orderFlowFee.behavior.t.sol
@@ -147,7 +147,8 @@ contract OrderFlowFeeTest is Test, ConsolidatedEvents {
         }
     }
 
-    /// Verifies that OrderFlowFee is correctly sent from account margin to treasury when there is enough funds in account margin to cover orderFlowFee
+    /// Verifies that OrderFlowFee is correctly sent from account margin to treasury 
+    // when there is enough funds in account margin to cover orderFlowFee
     function test_imposeOrderFlowFee_account_margin() public {
         fundAccount(AMOUNT);
 
@@ -181,7 +182,8 @@ contract OrderFlowFeeTest is Test, ConsolidatedEvents {
         assertEq(treasuryPostBalance - treasuryPreBalance, imposedOrderFlowFee);
     }
 
-    /// Verifies that OrderFlowFee is correctly sent from market margin to treasury when there is no funds in account margin to cover orderFlowFee in account margin
+    /// Verifies that OrderFlowFee is correctly sent from market margin to treasury 
+    // when there is no funds in account margin to cover orderFlowFee in account margin
     function test_imposeOrderFlowFee_market_margin() public {
         fundAccount(AMOUNT);
 
@@ -213,7 +215,8 @@ contract OrderFlowFeeTest is Test, ConsolidatedEvents {
         assertEq(treasuryPostBalance - treasuryPreBalance, imposedOrderFlowFee);
     }
 
-    /// Verifies that OrderFlowFee is correctly sent from both market margin and account margin when there is not enough funds to cover orderFlowFee in account margin
+    /// Verifies that OrderFlowFee is correctly sent from both market margin and account margin 
+    // when there is not enough funds to cover orderFlowFee in account margin
     function test_imposeOrderFlowFee_both_margin() public {
         fundAccount(AMOUNT);
 

--- a/test/integration/orderFlowFee.behavior.t.sol
+++ b/test/integration/orderFlowFee.behavior.t.sol
@@ -98,7 +98,7 @@ contract OrderFlowFeeTest is Test, ConsolidatedEvents {
             systemStatus,
             GELATO,
             OPS,
-            address(0),
+            address(settings),
             UNISWAP_UNIVERSAL_ROUTER,
             UNISWAP_PERMIT2
         );

--- a/test/unit/Events.t.sol
+++ b/test/unit/Events.t.sol
@@ -305,5 +305,15 @@ contract EventsTest is Test, ConsolidatedEvents {
         });
     }
 
-    /// @custom:todo test event for order flow fee imposed as done above
+    function test_emitOrderFlowFeeImposed_Event() public {
+        vm.expectEmit(true, true, true, true);
+        emit OrderFlowFeeImposed(address(account), AMOUNT);
+        vm.prank(account);
+        events.emitOrderFlowFeeImposed({amount: AMOUNT});
+    }
+
+    function test_emitOrderFlowFeeImposed_OnlyAccounts() public {
+        vm.expectRevert(abi.encodeWithSelector(IEvents.OnlyAccounts.selector));
+        events.emitOrderFlowFeeImposed({amount: AMOUNT});
+    }
 }

--- a/test/unit/Settings.t.sol
+++ b/test/unit/Settings.t.sol
@@ -5,6 +5,8 @@ import {Test} from "lib/forge-std/src/Test.sol";
 
 import {Settings} from "src/Settings.sol";
 
+import {ISettings} from "src/interfaces/ISettings.sol";
+
 import {ConsolidatedEvents} from "test/utils/ConsolidatedEvents.sol";
 
 import {MARGIN_ASSET, USER} from "test/utils/Constants.sol";
@@ -116,18 +118,26 @@ contract SettingsTest is Test, ConsolidatedEvents {
     //////////////////////////////////////////////////////////////*/
 
     function test_setOrderFlowFee(uint256 fee) public {
-        /// @custom:todo
+        if (fee > 100_000) {
+            vm.expectRevert(
+                abi.encodeWithSelector(ISettings.InvalidOrderFlowFee.selector)
+            );
+            settings.setOrderFlowFee(fee);
+        } else {
+            settings.setOrderFlowFee(fee);
+            assertEq(settings.orderFlowFee(), fee);
+        }
     }
 
     function test_setOrderFlowFee_OnlyOwner() public {
-        /// @custom:todo
+        vm.expectRevert("UNAUTHORIZED");
+        vm.prank(USER);
+        settings.setExecutorFee(5);
     }
 
     function test_setOrderFlowFee_Event() public {
-        /// @custom:todo
-    }
-
-    function test_setOrderFlowFee_InvalidOrderFlowFee() public {
-        /// @custom:todo
+        vm.expectEmit(true, true, true, true);
+        emit ExecutorFeeSet(5);
+        settings.setExecutorFee(5);
     }
 }

--- a/test/unit/Settings.t.sol
+++ b/test/unit/Settings.t.sol
@@ -118,7 +118,7 @@ contract SettingsTest is Test, ConsolidatedEvents {
     //////////////////////////////////////////////////////////////*/
 
     function test_setOrderFlowFee(uint256 fee) public {
-        if (fee > 100_000) {
+        if (fee > settings.MAX_ORDER_FLOW_FEE()) {
             vm.expectRevert(
                 abi.encodeWithSelector(ISettings.InvalidOrderFlowFee.selector)
             );

--- a/test/utils/ConsolidatedEvents.sol
+++ b/test/utils/ConsolidatedEvents.sol
@@ -85,6 +85,8 @@ contract ConsolidatedEvents {
         IAccount.PriceOracleUsed priceOracle
     );
 
+    event OrderFlowFeeImposed(address indexed account, uint256 amount);
+
     /*//////////////////////////////////////////////////////////////
                                ISETTINGS
     //////////////////////////////////////////////////////////////*/


### PR DESCRIPTION
Add `OrderFlowFee` logic for Delayed orders, add Event on `OrderFlowFeeImposed`, add tests for both `setOrderFlowFee` and `_imposeOrderFlowFee` functionnalities.

## Description
* Overloads `_imposeOrderFlowFee` and `_calculateOrderFlowFee` with `uint256 _desiredFillPrice`, which is set only for delayedOrders (setting a Delayed order on desired price 0 would result in paying the fee at the current price, but this edge case is not relevant as having 0 as fill price is irrelevant)
* Add `emitOrderFlowFeeImposed` event logic
* Add tests for `test_imposeOrderFlowFee`

## Motivation and Context
Part of KIP-122